### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/JannikEmmerich/nova/security/code-scanning/16](https://github.com/JannikEmmerich/nova/security/code-scanning/16)

To fix the problem, you should add a `permissions` block—either at the workflow level (affecting all jobs), or specifically to the jobs as needed. As a baseline, set `permissions: { contents: read }` at the workflow level, because all jobs require at least the ability to fetch source code. If specific jobs need more (e.g., write access for pull requests, or deployments), those jobs can have their own `permissions` block that grants the least-privilege required. Here, all jobs except possibly `publish` only need read permissions, so we set at the workflow root:

```yaml
permissions:
  contents: read
```

If in the future you add jobs needing more (e.g., `pull-requests: write`), override `permissions` for that job only.

**Where to change:**  
- Add the `permissions` block at the top-level, after the `name` field but before `on`.
- No imports or new methods are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
