### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yaml
+++ b/.github/workflows/gradle-wrapper-validation.yaml
@@ -1,4 +1,6 @@
 name: Validate Gradle Wrapper
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/JannikEmmerich/nova/security/code-scanning/13](https://github.com/JannikEmmerich/nova/security/code-scanning/13)

The best way to fix the problem is to add a `permissions` block with the least privileges necessary to the workflow. Given that the steps shown only check out the code (`actions/checkout@v5`) and validate the Gradle wrapper (`gradle/wrapper-validation-action@v3`), no write permissions are needed. The minimal permission for such read-only operations is `contents: read`. For maximum clarity and future-proofing, place the `permissions` block at the workflow root (before or after the `on:` block), so it applies to the entire workflow and all jobs by default. Add the block after the `name:` and before `on:` for readability and consistency.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
